### PR TITLE
fixing up the yaml section of the api since it has a 404

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -29,8 +29,9 @@ This file contains every LOLBAS entry in a single file, using the same structure
 This file contains every LOLBAS entry in a single file, broken down by LOLBAS file and command.
 
 ## YAML
-**Entry point**: <a href="https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/yml/">https://raw.githubusercontent.com/LOLBAS-Project/LOLBAS/master/yml/</a>
+**Entry point**: <a href="https://github.com/LOLBAS-Project/LOLBAS/tree/master/yml">https://github.com/LOLBAS-Project/LOLBAS/tree/master/yml</a>
 
 **Type**: File per entry
 
-Finally, it is possible to access the raw YAML files via GitHub. The file structure can be found on <a href="https://github.com/LOLBAS-Project/LOLBAS/tree/master/yml">GitHub</a>.
+Finally, it is possible to access the raw YAML files via GitHub. 
+


### PR DESCRIPTION
I noticed the YAML url was broken, also the link to Github was the same thing. I just cleaned up the page a bit. 

![Screenshot from 2023-02-28 20-02-08](https://user-images.githubusercontent.com/1476868/222019412-087b3226-8d35-43d0-b75d-2e5eb8889450.png)
